### PR TITLE
Add env package

### DIFF
--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -1,0 +1,1 @@
+export { env } from "@rp/env";

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@rp/ui/*": ["../../packages/ui/src/*"]
+      "@rp/ui/*": ["../../packages/ui/src/*"],
+      "@rp/env": ["../../packages/env/src/index.ts"]
     },
     "plugins": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,17 @@
         "typescript": "^5",
       },
     },
+    "packages/env": {
+      "name": "@rp/env",
+      "version": "0.0.1",
+      "dependencies": {
+        "@t3-oss/env-nextjs": "^0.13.6",
+        "zod": "^3.25.0",
+      },
+      "devDependencies": {
+        "@rp/typescript-config": "workspace:*",
+      },
+    },
     "packages/ui": {
       "name": "@rp/ui",
       "version": "0.0.0",
@@ -368,6 +379,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@rp/env": ["@rp/env@workspace:packages/env"],
+
     "@rp/typescript-config": ["@rp/typescript-config@workspace:toolings/typescript-config"],
 
     "@rp/ui": ["@rp/ui@workspace:packages/ui"],
@@ -377,6 +390,10 @@
     "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
+    "@t3-oss/env-core": ["@t3-oss/env-core@0.13.6", "", { "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0-beta.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-rH7FgcB1YGbv/tvv7mdJAxnNvRkK/gEqdVYBwO1AVvaWOTNuftqskxkEYyhM2O+lkNPJmTq5YBE7H+Unl7CLjg=="],
+
+    "@t3-oss/env-nextjs": ["@t3-oss/env-nextjs@0.13.6", "", { "dependencies": { "@t3-oss/env-core": "0.13.6" }, "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0-beta.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-KcA5U8L+Be4OuR5YxmrBzkeo7WsKkEFJDwcAgYFwcBgxxc3oJBdTB7KPQfVrx7wjtX5aDr2jZ0LG55yEXqQi9A=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.8", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "enhanced-resolve": "^5.18.1", "jiti": "^2.4.2", "lightningcss": "1.30.1", "magic-string": "^0.30.17", "source-map-js": "^1.2.1", "tailwindcss": "4.1.8" } }, "sha512-OWwBsbC9BFAJelmnNcrKuf+bka2ZxCE2A4Ft53Tkg4uoiE67r/PMEYwCsourC26E+kmxfwE0hVzMdxqeW+xu7Q=="],
 

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@rp/env",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "biome lint ."
+  },
+  "dependencies": {
+    "@t3-oss/env-nextjs": "^0.13.6",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@rp/typescript-config": "workspace:*"
+  }
+}

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,0 +1,37 @@
+import { createEnv } from "@t3-oss/env-nextjs";
+import { z } from "zod";
+
+const shared = {
+  NODE_ENV: z
+    .enum(["development", "production", "test"])
+    .default("development"),
+};
+
+const client = {
+  NEXT_PUBLIC_APP_URL: z.string().url().optional(),
+};
+
+const server = {
+  DATABASE_URL: z.string().url().optional(),
+};
+
+export const env = createEnv({
+  shared,
+  client,
+  server,
+  experimental__runtimeEnv: {
+    NODE_ENV: process.env.NODE_ENV,
+    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  },
+  skipValidation: !!process.env.CI || process.env.npm_lifecycle_event === "lint",
+});
+
+export const serverEnv = {
+  NODE_ENV: env.NODE_ENV,
+  DATABASE_URL: env.DATABASE_URL,
+};
+
+export const clientEnv = {
+  NODE_ENV: env.NODE_ENV,
+  NEXT_PUBLIC_APP_URL: env.NEXT_PUBLIC_APP_URL,
+};

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -20,18 +20,10 @@ export const env = createEnv({
   client,
   server,
   experimental__runtimeEnv: {
-    NODE_ENV: process.env.NODE_ENV,
+    NODE_ENV: process.env["NODE_ENV"],
     NEXT_PUBLIC_APP_URL: process.env["NEXT_PUBLIC_APP_URL"],
   },
-  skipValidation: !!process.env.CI || process.env.npm_lifecycle_event === "lint",
+  skipValidation:
+    !!process.env["CI"] || process.env["npm_lifecycle_event"] === "lint",
 });
 
-export const serverEnv = {
-  NODE_ENV: env.NODE_ENV,
-  DATABASE_URL: env.DATABASE_URL,
-};
-
-export const clientEnv = {
-  NODE_ENV: env.NODE_ENV,
-  NEXT_PUBLIC_APP_URL: env.NEXT_PUBLIC_APP_URL,
-};

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -21,7 +21,7 @@ export const env = createEnv({
   server,
   experimental__runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
-    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+    NEXT_PUBLIC_APP_URL: process.env["NEXT_PUBLIC_APP_URL"],
   },
   skipValidation: !!process.env.CI || process.env.npm_lifecycle_event === "lint",
 });

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@rp/typescript-config/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@rp/env": ["./src/index.ts"]
+    }
+  },
+  "include": ["./src"],
+  "files": ["../../reset.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add new `@rp/env` package with typed env using `@t3-oss/env-nextjs`
- expose env for the web app and add path alias
- refactor env schema to share client and server options
- update lockfile

## Testing
- `bun run lint`
- `bun run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68403df55f7883219f9482b6a8aa44e4