### PR TITLE
Add Supabase domains type

### DIFF
--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -52,3 +52,31 @@ The package exposes helper functions under `@rp/supabase/queries` and
 Utility helpers for uploading, downloading and removing files are exported from
 `@rp/supabase/storage`.
 
+### Dynamic Table Example
+
+To add a custom table such as `blog` with fields like `title`, `created_at` and
+`published`, define the table in your Supabase migrations and regenerate the
+TypeScript types. A minimal SQL migration might look like:
+
+```sql
+create table blog (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  created_at timestamp with time zone default now(),
+  published boolean default false
+);
+```
+
+Run `supabase gen types typescript --linked` to update
+`packages/supabase/src/types/db.ts`. After regenerating, re-export the table's
+CRUD types:
+
+```ts
+export type BlogRow = Database["public"]["Tables"]["blog"]["Row"];
+export type BlogInsert = Database["public"]["Tables"]["blog"]["Insert"];
+export type BlogUpdate = Database["public"]["Tables"]["blog"]["Update"];
+```
+
+These exports provide strongly typed access to the new table across your
+application.
+

--- a/packages/supabase/src/types/db.ts
+++ b/packages/supabase/src/types/db.ts
@@ -1962,6 +1962,42 @@ export type Database = {
           },
         ];
       };
+      domains: {
+        Row: {
+          created_at: string;
+          domain: string;
+          id: string;
+          team_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          domain: string;
+          id?: string;
+          team_id: string;
+        };
+        Update: {
+          created_at?: string;
+          domain?: string;
+          id?: string;
+          team_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "domains_team_id_fkey";
+            columns: ["team_id"];
+            isOneToOne: false;
+            referencedRelation: "team_limits_metrics";
+            referencedColumns: ["team_id"];
+          },
+          {
+            foreignKeyName: "domains_team_id_fkey";
+            columns: ["team_id"];
+            isOneToOne: false;
+            referencedRelation: "teams";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
     };
     Views: {
       team_limits_metrics: {

--- a/packages/supabase/src/types/index.ts
+++ b/packages/supabase/src/types/index.ts
@@ -4,3 +4,7 @@ import type { Database } from "../types/db";
 export type Client = SupabaseClient<Database>;
 
 export * from "./db";
+
+export type DomainRow = Database["public"]["Tables"]["domains"]["Row"];
+export type DomainInsert = Database["public"]["Tables"]["domains"]["Insert"];
+export type DomainUpdate = Database["public"]["Tables"]["domains"]["Update"];


### PR DESCRIPTION
## Summary
- define `domains` table types in Supabase DB schema
- expose `DomainRow`, `DomainInsert`, and `DomainUpdate` for convenience
- document how to add new tables like `blog` and regenerate types

## Testing
- `npx --yes turbo lint` *(fails: biome not found)*
- `npx tsc -p packages/supabase/tsconfig.json --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684058827d7c83219f061380bd5bc681