### PR TITLE
Add redis caching package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,8 +44,20 @@
         "zod": "^3.25.0",
       },
       "devDependencies": {
-        "@rp/typescript-config": "workspace:*"
-      }
+        "@rp/typescript-config": "workspace:*",
+      },
+    },
+    "packages/kv": {
+      "name": "@rp/kv",
+      "version": "0.0.0",
+      "dependencies": {
+        "@upstash/ratelimit": "^2.0.2",
+        "@upstash/redis": "^1.34.0",
+        "server-only": "^0.0.1",
+      },
+      "devDependencies": {
+        "typescript": "^5.8.3",
+      },
     },
     "packages/supabase": {
       "name": "@rp/supabase",
@@ -396,7 +408,9 @@
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
     "@rp/env": ["@rp/env@workspace:packages/env"],
-    
+
+    "@rp/kv": ["@rp/kv@workspace:packages/kv"],
+
     "@rp/supabase": ["@rp/supabase@workspace:packages/supabase"],
 
     "@rp/typescript-config": ["@rp/typescript-config@workspace:toolings/typescript-config"],
@@ -514,6 +528,12 @@
     "@types/tinycolor2": ["@types/tinycolor2@1.4.6", "", {}, "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@upstash/core-analytics": ["@upstash/core-analytics@0.0.10", "", { "dependencies": { "@upstash/redis": "^1.28.3" } }, "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ=="],
+
+    "@upstash/ratelimit": ["@upstash/ratelimit@2.0.5", "", { "dependencies": { "@upstash/core-analytics": "^0.0.10" }, "peerDependencies": { "@upstash/redis": "^1.34.3" } }, "sha512-1FRv0cs3ZlBjCNOCpCmKYmt9BYGIJf0J0R3pucOPE88R21rL7jNjXG+I+rN/BVOvYJhI9niRAS/JaSNjiSICxA=="],
+
+    "@upstash/redis": ["@upstash/redis@1.35.0", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-WUm0Jz1xN4DBDGeJIi2Y0kVsolWRB2tsVds4SExaiLg4wBdHFMB+8IfZtBWr+BP0FvhuBr5G1/VLrJ9xzIWHsg=="],
 
     "JSONStream": ["JSONStream@1.3.5", "", { "dependencies": { "jsonparse": "^1.2.0", "through": ">=2.2.7 <3" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
 
@@ -1204,6 +1224,8 @@
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
+    "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "@rp/kv",
+	"version": "0.0.0",
+	"private": true,
+	"exports": {
+		"./client": "./src/index.ts",
+		"./ratelimit": "./src/ratelimit.ts"
+	},
+	"scripts": {
+		"lint": "biome lint ."
+	},
+	"dependencies": {
+		"@upstash/ratelimit": "^2.0.2",
+		"@upstash/redis": "^1.34.0",
+		"server-only": "^0.0.1"
+	},
+	"devDependencies": {
+		"typescript": "^5.8.3"
+	}
+}

--- a/packages/kv/src/index.ts
+++ b/packages/kv/src/index.ts
@@ -1,0 +1,8 @@
+import "server-only"
+
+import { Redis } from "@upstash/redis"
+
+export const client = new Redis({
+  url: process.env["UPSTASH_REDIS_REST_URL"]!,
+  token: process.env["UPSTASH_REDIS_REST_TOKEN"]!,
+})

--- a/packages/kv/src/ratelimit.ts
+++ b/packages/kv/src/ratelimit.ts
@@ -1,0 +1,14 @@
+import "server-only"
+
+import { Ratelimit } from "@upstash/ratelimit"
+import { client } from "."
+
+export const config = {
+  limit: 10,
+  window: "10s",
+} as const
+
+export const ratelimit = new Ratelimit({
+  limiter: Ratelimit.fixedWindow(config.limit, config.window),
+  redis: client,
+})

--- a/packages/kv/tsconfig.json
+++ b/packages/kv/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "@rp/typescript-config/base.json",
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@rp/kv/*": ["./src/*"]
+		}
+	},
+	"include": ["src"],
+	"files": ["../../reset.d.ts"],
+	"exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add @rp/kv package with Upstash client and rate limiter
- include UPSTASH env vars
- use bracket notation for env access
- integrate redis caching in domain actions
- expose kv path alias in web tsconfig

## Testing
- `bun run lint`
- `UPSTASH_REDIS_REST_URL=http://127.0.0.1 UPSTASH_REDIS_REST_TOKEN=token bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6841b045e5ac83218e1d5a1c2449811e